### PR TITLE
Update Camel-forge addon repository

### DIFF
--- a/addons-community.yaml
+++ b/addons-community.yaml
@@ -257,7 +257,7 @@ description: Setup/Manage Apache Camel in your project
 url: http://fabric8.io/guide/forge.html
 website: http://fabric8.io/guide/forge.html
 installCmd: addon-install --coordinate io.fabric8.forge:camel
-repo: https://github.com/fabric8io/fabric8.git
+repo: https://github.com/fabric8io/fabric8-forge.git
 path: /forge/addons/camel
 ref: master
 tags: camel, addon

--- a/addons-community.yaml
+++ b/addons-community.yaml
@@ -258,7 +258,7 @@ url: http://fabric8.io/guide/forge.html
 website: http://fabric8.io/guide/forge.html
 installCmd: addon-install --coordinate io.fabric8.forge:camel
 repo: https://github.com/fabric8io/fabric8-forge.git
-path: /forge/addons/camel
+path: /addons/camel
 ref: master
 tags: camel, addon
 logo: http://design.jboss.org/fabric8/logo/final/fabric8_icon_32px.png


### PR DESCRIPTION
Hi @gastaldi ,

Just a little update in docs. The camel-forge addon has a new repository now: https://github.com/fabric8io/fabric8-forge

Thank you,
Andrea